### PR TITLE
Adapted the code to PhotoFlow needs

### DIFF
--- a/src/demosaic/amaze.cc
+++ b/src/demosaic/amaze.cc
@@ -38,7 +38,7 @@
 
 namespace
 {
-unsigned fc(const ColorFilterArray &cfa, unsigned row, unsigned col)
+unsigned fc(const librtprocess::ColorFilterArray &cfa, unsigned row, unsigned col)
 {
     return cfa[row & 1][col & 1];
 }
@@ -55,6 +55,8 @@ void amaze_demosaic(int winx, int winy, int winw, int winh, const array2D<float>
     setProgCancel(progress);
 
     const int width = winw, height = winh;
+    const int raw_width = rawData.width();
+    const int raw_height = rawData.height();
     const float clip_pt = 1.0 / initGain;
     const float clip_pt8 = 0.8 / initGain;
 
@@ -199,8 +201,10 @@ void amaze_demosaic(int winx, int winy, int winw, int winh, const array2D<float>
                 // min and max row/column in the tile
                 int rrmin = top < winy ? 16 : 0;
                 int ccmin = left < winx ? 16 : 0;
-                int rrmax = bottom > (winy + height) ? winy + height - top : rr1;
-                int ccmax = right > (winx + width) ? winx + width - left : cc1;
+                //int rrmax = bottom > (winy + height) ? winy + height - top : rr1;
+                int rrmax = bottom > (raw_height) ? winy + height - top : rr1;
+                //int ccmax = right > (winx + width) ? winx + width - left : cc1;
+                int ccmax = right > (raw_width) ? winx + width - left : cc1;
 
                 // rgb from input CFA data
                 // rgb values should be floating point number between 0 and 1

--- a/src/demosaic/amaze.cc
+++ b/src/demosaic/amaze.cc
@@ -38,7 +38,7 @@
 
 namespace
 {
-unsigned fc(const librtprocess::ColorFilterArray &cfa, unsigned row, unsigned col)
+unsigned fc(const ColorFilterArray &cfa, unsigned row, unsigned col)
 {
     return cfa[row & 1][col & 1];
 }

--- a/src/demosaic/border.cc
+++ b/src/demosaic/border.cc
@@ -22,7 +22,7 @@
 
 namespace
 {
-unsigned fc(const librtprocess::ColorFilterArray &cfa, unsigned row, unsigned col)
+unsigned fc(const ColorFilterArray &cfa, unsigned row, unsigned col)
 {
     return cfa[row & 1][col & 1];
 }

--- a/src/demosaic/border.cc
+++ b/src/demosaic/border.cc
@@ -22,7 +22,7 @@
 
 namespace
 {
-unsigned fc(const ColorFilterArray &cfa, unsigned row, unsigned col)
+unsigned fc(const librtprocess::ColorFilterArray &cfa, unsigned row, unsigned col)
 {
     return cfa[row & 1][col & 1];
 }

--- a/src/librtprocess.h
+++ b/src/librtprocess.h
@@ -53,7 +53,7 @@ namespace librtprocess
   };
 
     void amaze_demosaic(int winx, int winy, int winw, int winh, const array2D<float> &rawData, array2D<float> &red, array2D<float> &green, array2D<float> &blue, const ColorFilterArray &cfarray, const std::function<bool(double)> &setProgCancel, double initGain, int border, float inputScale = 65535.f, float outputScale = 65535.f);
-    bool CA_correct(int W, int H, const bool autoCA, const double cared, const double cablue, array2D<float> &rawData, const ColorFilterArray &cfarray, const std::function<bool(double)> &setProgCancel, CaFitParams &fitParams, bool fitParamsIn, float inputScale = 65535.f, float outputScale = 65535.f);
+    bool CA_correct(int winx, int winy, int winw, int winh, const bool autoCA, const double cared, const double cablue, array2D<float> &rawData, array2D<float> &rawDataOut, const ColorFilterArray &cfarray, const std::function<bool(double)> &setProgCancel, CaFitParams &fitParams, bool fitParamsIn, float inputScale = 65535.f, float outputScale = 65535.f);
 
 }//namespace
 

--- a/src/librtprocess.h
+++ b/src/librtprocess.h
@@ -25,32 +25,10 @@
 
 #include "array2D.h"
 
-//using ColorFilterArray = std::array<std::array<unsigned, 3>, 3>;
+using ColorFilterArray = std::array<std::array<unsigned, 2>, 2>;
 using CaFitParams = std::array<std::array<std::array<double, 16>, 2>, 2>;
 namespace librtprocess
 {
-  class ColorFilterArray: public std::array<std::array<unsigned, 3>, 3>
-  {
-    void init(int filters)
-    {
-      for(int row = 0; row < 2; row++) {
-        for(int col = 0; col < 2; col++) {
-          (*this)[row][col] = (filters >> ((((row) << 1 & 14) + ((col) & 1)) << 1) & 3);
-        }
-      }
-    }
-
-  public:
-    ColorFilterArray(int filters)
-    {
-      init(filters);
-    }
-
-    void set_cfa(int filters)
-    {
-      init(filters);
-    }
-  };
 
     void amaze_demosaic(int winx, int winy, int winw, int winh, const array2D<float> &rawData, array2D<float> &red, array2D<float> &green, array2D<float> &blue, const ColorFilterArray &cfarray, const std::function<bool(double)> &setProgCancel, double initGain, int border, float inputScale = 65535.f, float outputScale = 65535.f);
     bool CA_correct(int winx, int winy, int winw, int winh, const bool autoCA, const double cared, const double cablue, array2D<float> &rawData, array2D<float> &rawDataOut, const ColorFilterArray &cfarray, const std::function<bool(double)> &setProgCancel, CaFitParams &fitParams, bool fitParamsIn, float inputScale = 65535.f, float outputScale = 65535.f);

--- a/src/librtprocess.h
+++ b/src/librtprocess.h
@@ -25,10 +25,32 @@
 
 #include "array2D.h"
 
-using ColorFilterArray = std::array<std::array<unsigned, 2>, 2>;
+//using ColorFilterArray = std::array<std::array<unsigned, 3>, 3>;
 using CaFitParams = std::array<std::array<std::array<double, 16>, 2>, 2>;
 namespace librtprocess
 {
+  class ColorFilterArray: public std::array<std::array<unsigned, 3>, 3>
+  {
+    void init(int filters)
+    {
+      for(int row = 0; row < 2; row++) {
+        for(int col = 0; col < 2; col++) {
+          (*this)[row][col] = (filters >> ((((row) << 1 & 14) + ((col) & 1)) << 1) & 3);
+        }
+      }
+    }
+
+  public:
+    ColorFilterArray(int filters)
+    {
+      init(filters);
+    }
+
+    void set_cfa(int filters)
+    {
+      init(filters);
+    }
+  };
 
     void amaze_demosaic(int winx, int winy, int winw, int winh, const array2D<float> &rawData, array2D<float> &red, array2D<float> &green, array2D<float> &blue, const ColorFilterArray &cfarray, const std::function<bool(double)> &setProgCancel, double initGain, int border, float inputScale = 65535.f, float outputScale = 65535.f);
     bool CA_correct(int W, int H, const bool autoCA, const double cared, const double cablue, array2D<float> &rawData, const ColorFilterArray &cfarray, const std::function<bool(double)> &setProgCancel, CaFitParams &fitParams, bool fitParamsIn, float inputScale = 65535.f, float outputScale = 65535.f);

--- a/src/preprocess/CA_correct.cc
+++ b/src/preprocess/CA_correct.cc
@@ -105,7 +105,7 @@ bool LinEqSolve(int nDim, double* pfMatr, double* pfVect, std::array<double, 16>
 //end of linear equation solver
 //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-unsigned fc(const librtprocess::ColorFilterArray &cfa, unsigned row, unsigned col)
+unsigned fc(const ColorFilterArray &cfa, unsigned row, unsigned col)
 {
     return cfa[row & 1][col & 1];
 }

--- a/src/preprocess/CA_correct.cc
+++ b/src/preprocess/CA_correct.cc
@@ -105,7 +105,7 @@ bool LinEqSolve(int nDim, double* pfMatr, double* pfVect, std::array<double, 16>
 //end of linear equation solver
 //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-unsigned fc(const ColorFilterArray &cfa, unsigned row, unsigned col)
+unsigned fc(const librtprocess::ColorFilterArray &cfa, unsigned row, unsigned col)
 {
     return cfa[row & 1][col & 1];
 }

--- a/src/preprocess/CA_correct.cc
+++ b/src/preprocess/CA_correct.cc
@@ -1133,11 +1133,13 @@ bool CA_correct(int winx, int winy, int winw, int winh, const bool autoCA, const
                         int indx = ((row-winy) * winw + cc + left - winx) >> 1;
                         int indx_max = ((row-winy) * winw + cc1 - border + left - winx) >> 1;
                         int indx1 = (rr * ts + cc) >> 1;
-#ifdef __SSE2___
+/*
+#ifdef __SSE2__
                         for (; indx < (row * width + cc1 - border - 7 + left) >> 1; indx+=4, indx1 += 4) {
                             STVFU(RawDataTmp[indx], coutScalev * LVFU(rgb[c][indx1]));
                         }
 #endif
+*/
                         for (; indx < indx_max /*(row * width + cc1 - border + left) >> 1*/; indx++, indx1++) {
                             RawDataTmp[indx] = outputScale * rgb[c][indx1];
                         }
@@ -1168,6 +1170,7 @@ bool CA_correct(int winx, int winy, int winw, int winh, const bool autoCA, const
                 //int indx = (row * width + col) >> 1;
                 int col = fc(cfarray, row+winy, 0) & 1;
                 int indx = (row * winw + col) >> 1;
+/*
 #ifdef __SSE2__
                 //for(; col < width - 7; col += 8, indx += 4) {
                 for(; col < winw - 7; col += 8, indx += 4) {
@@ -1175,6 +1178,7 @@ bool CA_correct(int winx, int winy, int winw, int winh, const bool autoCA, const
                     STC2VFU(rawDataOut[row+winy][col+winx], LVFU(RawDataTmp[indx]));
                 }
 #endif
+*/
                 //for(; col < width - (W & 1); col += 2, indx++) {
                 for(; col < winw; col += 2, indx++) {
                     //rawData[row][col] = RawDataTmp[indx];


### PR DESCRIPTION
I have started to adapt the LibRTProcess code to the peculiar needs of PhotoFlow’s processing pipeline.

The good news is that it works, and that the inclusion of the LibRTProcess code was rather easy.
hence, if you plan to add more algorithms to the library I will be very happy!
The experimental code is in the [rtprocess branch](https://github.com/aferrero2707/PhotoFlow/tree/rtprocess).

LibRTProcess required some modifications in order to make it compatible with PhotoFlow.
Here is a short description of the changes:

- Array2D: I have introduced a special constructor that allows to create a pixel matrix that only contains a portion of the entire image, but that can be addressed as if the entire image was available (i.e. using row and column indexes from the top-left corner) This is obtained using some simple pointer arithmetics, however there are for the moment no checks to prevent out-of-bounds accesses.

- Amaze: I have modified the code such that the “winw” and “winh” parameters really represent the extents of a sub-portion of the entire image. I have the impression that this was also the original idea of the code, but as far as I understand the code should use the total width of the RAW  image, and not the width of the processed window, to handle the boundary conditions. I have tried to fix that in my version

- CA correction: like in the Amaze case, I need to have the possibility to apply the CA correction to a portion of the entire image, therefore I have introduced some winx/winy/winw/winh parameters like for the Amaze case. The total width and height of the RAW image is directly taken from the rawData object

- CA correction: I have temporarily disabled a couple of SSE2 optimisations at the end of the routine, just until I am sure I am handling the indexes correctly

Let me know what you think!