### PR TITLE
Fix source comment typos

### DIFF
--- a/CompilerChecks.cmake
+++ b/CompilerChecks.cmake
@@ -63,7 +63,7 @@ if (UNIX)
         check_cxx_compiler_flag_ssp("-fstack-protector" WITH_STACK_PROTECTOR)
         if (WITH_STACK_PROTECTOR)
             list(APPEND SUPPORTED_CXX_COMPILER_FLAGS "-fstack-protector")
-            # This is needed as Solaris has a seperate libssp
+            # This is needed as Solaris has a separate libssp
             if (SOLARIS)
                 list(APPEND SUPPORTED_LINKER_FLAGS "-fstack-protector")
             endif()

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ the logic to convert from/to this structure.
 		for (unsigned i=1; i<h; i++) 
 			blue[i]     = blue[i - 1] + w;
 
-    //loads the internal data to the librtprocess rawData structure.  The interal data's red channel 
+    //loads the internal data to the librtprocess rawData structure.  The internal data's red channel 
     //is arbitrarily chosen as a monochrome image is represented R=G=B:
 		#pragma omp parallel for num_threads(threadcount)
 		for (unsigned y=0; y<h; y++) {

--- a/cmake/Modules/DefineCMakeDefaults.cmake
+++ b/cmake/Modules/DefineCMakeDefaults.cmake
@@ -6,7 +6,7 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
 # Put the include dirs which are in the source or build tree
 # before all other include dirs, so the headers in the sources
-# are prefered over the already installed ones
+# are preferred over the already installed ones
 # since cmake 2.4.1
 set(CMAKE_INCLUDE_DIRECTORIES_PROJECT_BEFORE ON)
 

--- a/src/demosaic/ahd.cc
+++ b/src/demosaic/ahd.cc
@@ -187,7 +187,7 @@ rpError ahd_demosaic(int width, int height, const float * const *rawData, float 
                     }
                 }
 
-                //  Combine the most homogenous pixels for the final result:
+                //  Combine the most homogeneous pixels for the final result:
                 for (int row = top + 3; row < top + TS - 3 && row < height - 5; row++) {
                     int tr = row - top;
 

--- a/src/include/LUT.h
+++ b/src/include/LUT.h
@@ -518,7 +518,7 @@ public:
         }
     }
 
-    // compress a LUT<uint32_t> with size y into a LUT<uint32_t> with size x (y>x) by using the passTrough LUT to calculate indexes
+    // compress a LUT<uint32_t> with size y into a LUT<uint32_t> with size x (y>x) by using the passThrough LUT to calculate indexes
     template<typename U = T, typename = typename std::enable_if<std::is_same<U, std::uint32_t>::value>::type>
     void compressTo(LUT<T> &dest, unsigned int numVals, const LUT<float> &passThrough) const
     {


### PR DESCRIPTION
Found via `codespell -q 3 -L ba,bord,datas,rady`