### PR TITLE
Fix include for size_t

### DIFF
--- a/src/include/librtprocess.h
+++ b/src/include/librtprocess.h
@@ -20,6 +20,8 @@
 #ifndef _LIBRTPROCESS_
 #define _LIBRTPROCESS_
 
+#include <stddef.h>
+
 #include <functional>
 #include <cstddef>
 


### PR DESCRIPTION
On recent gcc, `size_t` is no longer implicitly defined in the headers already included. `stddef.h` needs to be included.