### PR TITLE
Fixed compilation in static builds.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -25,6 +25,13 @@ target_include_directories(rtprocess
                            PUBLIC
                                $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
                                $<INSTALL_INTERFACE:include>)
+
+if(NOT BUILD_SHARED_LIBS)
+    target_compile_definitions(rtprocess
+                               PRIVATE
+                                LIBRTPROCESS_STATIC)
+endif()
+
 target_compile_options(rtprocess
                        PRIVATE
                            ${OpenMP_CXX_FLAGS}

--- a/src/include/librtprocess.h
+++ b/src/include/librtprocess.h
@@ -25,14 +25,22 @@
 #include <functional>
 #include <cstddef>
 
-#if defined( __WIN32__ ) || defined( _WIN32 )
-#   if defined( rtprocess_EXPORTS )
-#       define RTPROCESS_API __declspec( dllexport )
+#ifndef LIBRTPROCESS_STATIC
+// DLL interface export/import macros are only available for MSVC for now, 
+// in order to keep compatibility with previous versions of librtprocess 
+//#   if defined( __WIN32__ ) || defined( _WIN32 )
+#   ifdef _MSC_VER
+#       if defined( rtprocess_EXPORTS ) 
+#           define RTPROCESS_API __declspec( dllexport )
+#       else
+#           define RTPROCESS_API __declspec( dllimport )
+#       endif
 #   else
-#       define RTPROCESS_API __declspec( dllimport )
+//#     define RTPROCESS_API  __attribute__ ((visibility("default")))
+#       define RTPROCESS_API
 #   endif
-#else // non-windwos platform
-#   define RTPROCESS_API  __attribute__ ((visibility("default")))
+#else 
+#   define RTPROCESS_API
 #endif
 
 enum rpError {RP_NO_ERROR, RP_MEMORY_ERROR, RP_WRONG_CFA, RP_CACORRECT_ERROR};


### PR DESCRIPTION
I've broken static builds in PR #74 , assuming that all builds were dynamic. This patch addresses that, and enables the new macros only for MSVC builds; also, it forces you to define the LIBRTPROCESS_STATIC preprocessor directive from your project if statically linking the library (again, only for MSVC builds).