### PR TITLE
ProcessorTargets: fix native flags

### DIFF
--- a/ProcessorTargets.cmake
+++ b/ProcessorTargets.cmake
@@ -6,5 +6,8 @@ set(PROC_TARGET_1_FLAGS "-mtune=generic" CACHE STRING "Processor-1 flags")
 
 # This second choice should be used for your own build only
 set(PROC_TARGET_2_LABEL native CACHE STRING "Processor-2 label - use it for your own build")
-set(PROC_TARGET_2_FLAGS "-march=native" CACHE STRING "Processor-2 flags")
-
+if (CMAKE_SYSTEM_PROCESSOR MATCHES "ppc|ppc64|powerpc|powerpc64" OR (APPLE AND CMAKE_OSX_ARCHITECTURES MATCHES "ppc|ppc64"))
+  set(PROC_TARGET_2_FLAGS "-mtune=native" CACHE STRING "Processor-2 flags")
+else()
+  set(PROC_TARGET_2_FLAGS "-march=native" CACHE STRING "Processor-2 flags")
+endif()


### PR DESCRIPTION
There is no `-march=` on any PowerPC (regardless of OS). Use supported `-mtune=`.